### PR TITLE
feat: add automatic table of contents to blog posts

### DIFF
--- a/src/components/molecules/TableOfContents.tsx
+++ b/src/components/molecules/TableOfContents.tsx
@@ -1,0 +1,29 @@
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface TableOfContentsProps {
+  headings: Heading[];
+}
+
+const TableOfContents = ({ headings }: TableOfContentsProps) => {
+  const filtered = headings.filter((h) => h.depth === 2 || h.depth === 3);
+  if (filtered.length === 0) return null;
+
+  return (
+    <nav aria-label="目次" style={{ borderLeft: '3px solid #e5e5e5', paddingLeft: '1rem', margin: '1.5rem 0', fontSize: '0.9rem' }}>
+      <p style={{ fontWeight: '600', marginBottom: '0.5rem', color: '#555' }}>目次</p>
+      <ol style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {filtered.map((h) => (
+          <li key={h.slug} style={{ margin: '0.25rem 0', paddingLeft: h.depth === 3 ? '1rem' : '0' }}>
+            <a href={`#${h.slug}`} style={{ color: '#555' }}>{h.text}</a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+};
+
+export default TableOfContents;

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -4,6 +4,7 @@ import Layout from '../../layouts/Layout.astro';
 import PostHeader from '../../components/organisms/PostHeader';
 import PostNav from '../../components/molecules/PostNav';
 import BackButton from '../../components/molecules/BackButton';
+import TableOfContents from '../../components/molecules/TableOfContents';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts', ({ data }) => data.published !== false);
@@ -21,7 +22,7 @@ export async function getStaticPaths() {
 }
 
 const { post, prevPost, nextPost } = Astro.props;
-const { Content } = await post.render();
+const { Content, headings } = await post.render();
 
 const dateStr = post.data.date.toISOString().split('T')[0];
 ---
@@ -30,6 +31,7 @@ const dateStr = post.data.date.toISOString().split('T')[0];
   <BackButton />
   <article>
     <PostHeader title={post.data.title} date={dateStr} tags={post.data.tags || []} />
+    <TableOfContents headings={headings} />
     <div class="markdown">
       <Content />
     </div>


### PR DESCRIPTION
Astro の headings API を使い追加パッケージなしで実装。
h2・h3 見出しを抽出して記事ヘッダー直下に表示する。