### PR TITLE
add mermaid/kotlin rendering, tag sidebar, cover images, and wiki-lin…

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,12 +4,54 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { remarkWikiLinks } from './src/plugins/remarkWikiLinks.ts';
+import { remarkMermaid } from './src/plugins/remarkMermaid.ts';
+import { remarkKotlin } from './src/plugins/remarkKotlin.ts';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import fs from 'node:fs';
+import matter from 'gray-matter';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function buildSlugTitleMap() {
+  const postsDir = join(__dirname, 'src/content/posts');
+  const map = new Map();
+
+  function readDir(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        readDir(join(dir, entry.name));
+      } else if (entry.name.endsWith('.md')) {
+        try {
+          const content = fs.readFileSync(join(dir, entry.name), 'utf-8');
+          const { data } = matter(content);
+          if (typeof data.slug === 'string' && data.title) {
+            map.set(data.slug, String(data.title));
+          }
+        } catch {
+          // skip malformed files
+        }
+      }
+    }
+  }
+
+  readDir(postsDir);
+  return map;
+}
+
+const slugTitleMap = buildSlugTitleMap();
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [react()],
   markdown: {
-    remarkPlugins: [remarkGfm, remarkMath, remarkWikiLinks],
+    remarkPlugins: [
+      remarkGfm,
+      remarkMath,
+      [remarkWikiLinks, { slugTitleMap }],
+      remarkMermaid,
+      remarkKotlin,
+    ],
     rehypePlugins: [rehypeKatex],
     shikiConfig: {
       theme: 'one-dark-pro',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,13 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "check": "astro check"
+    "check": "astro check",
+    "emulators": "firebase emulators:start --only auth,firestore,storage,functions",
+    "emulators:export": "firebase emulators:export ./emulator-data",
+    "functions:build": "npm run build --prefix functions",
+    "functions:watch": "npm run build:watch --prefix functions",
+    "functions:deploy": "firebase deploy --only functions",
+    "dev:full": "concurrently \"npm run dev\" \"npm run emulators\""
   },
   "repository": {
     "type": "git",

--- a/src/components/molecules/PostCard.tsx
+++ b/src/components/molecules/PostCard.tsx
@@ -7,28 +7,40 @@ interface PostCardProps {
       title: string;
       date: Date | string;
       tags?: string[];
+      cover?: string | null;
     };
   };
 }
 
 const PostCard = ({ post }: PostCardProps) => {
-  const { title, date, tags = [] } = post.data;
+  const { title, date, tags = [], cover } = post.data;
+  const coverSrc = cover || `https://picsum.photos/seed/${post.slug}/80/56`;
   const dateStr = date instanceof Date ? date.toISOString().split('T')[0] : date;
 
   return (
-    <article style={{ borderBottom: '1px solid #e5e5e5', padding: '1rem 0' }}>
-      <a href={`/posts/${post.slug}`} style={{ fontWeight: '600', fontSize: '1rem', color: '#1a1a1a' }}>
-        {title}
-      </a>
-      <div style={{ marginTop: '0.25rem', fontSize: '0.85rem', color: '#888' }}>
-        <time dateTime={dateStr as string}>{dateStr}</time>
-        {tags.length > 0 && (
-          <span style={{ marginLeft: '0.75rem' }}>
-            {tags.map((tag) => (
-              <Tag key={tag}>{tag}</Tag>
-            ))}
-          </span>
-        )}
+    <article style={{ borderBottom: '1px solid #e5e5e5', padding: '1rem 0', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+      <div className="cover-img-wrap" style={{ width: '80px', flexShrink: 0 }}>
+        <img
+          src={coverSrc}
+          alt=""
+          className="cover-img"
+          style={{ width: '80px', height: '56px', objectFit: 'cover', borderRadius: '3px', display: 'block' }}
+        />
+      </div>
+      <div style={{ flex: 1 }}>
+        <a href={`/posts/${post.slug}`} style={{ fontWeight: '600', fontSize: '1rem', color: '#1a1a1a' }}>
+          {title}
+        </a>
+        <div style={{ marginTop: '0.25rem', fontSize: '0.85rem', color: '#888' }}>
+          <time dateTime={dateStr as string}>{dateStr}</time>
+          {tags.length > 0 && (
+            <span style={{ marginLeft: '0.75rem' }}>
+              {tags.map((tag) => (
+                <Tag key={tag}>{tag}</Tag>
+              ))}
+            </span>
+          )}
+        </div>
       </div>
     </article>
   );

--- a/src/components/organisms/TagSidebar.astro
+++ b/src/components/organisms/TagSidebar.astro
@@ -1,0 +1,43 @@
+---
+interface Props {
+  tags: { name: string; count: number }[];
+  currentTag?: string;
+}
+
+const { tags, currentTag } = Astro.props;
+const sorted = [...tags].sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+---
+
+<aside style="width: 160px; flex-shrink: 0; font-size: 0.8rem;">
+  <p style="color: #888; font-weight: 600; margin: 0 0 0.5rem; letter-spacing: 0.05em;">TAGS</p>
+  <input
+    id="tag-search"
+    type="text"
+    placeholder="search..."
+    style="width: 100%; box-sizing: border-box; padding: 0.25rem 0.4rem; font-size: 0.75rem; font-family: inherit; border: 1px solid #e5e5e5; border-radius: 3px; margin-bottom: 0.6rem; outline: none;"
+  />
+  <ul id="tag-list" style="list-style: none; padding: 0; margin: 0;">
+    {sorted.map(({ name, count }) => (
+      <li data-tag={name.toLowerCase()} style="margin-bottom: 0.2rem;">
+        <a
+          href={`/tags/${name}`}
+          style={`color: ${currentTag === name ? '#7c3aed' : '#555'}; font-weight: ${currentTag === name ? '600' : 'normal'};`}
+        >
+          {name}
+        </a>
+        <span style="color: #bbb; margin-left: 0.2rem;">({count})</span>
+      </li>
+    ))}
+  </ul>
+</aside>
+
+<script>
+  const input = document.getElementById('tag-search') as HTMLInputElement | null;
+  const items = document.querySelectorAll<HTMLLIElement>('#tag-list li[data-tag]');
+  input?.addEventListener('input', () => {
+    const q = input.value.toLowerCase();
+    items.forEach(li => {
+      li.style.display = (li.dataset.tag ?? '').includes(q) ? '' : 'none';
+    });
+  });
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,6 +36,10 @@ const adsClient = import.meta.env.PUBLIC_ADSENSE_CLIENT;
 		)}
 
 		<script is:inline src="https://unpkg.com/kotlin-playground@1" defer></script>
+		<script type="module" is:inline>
+			import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+			mermaid.initialize({ startOnLoad: true });
+		</script>
 	</head>
 	<body>
 		<Header />
@@ -57,6 +61,7 @@ const adsClient = import.meta.env.PUBLIC_ADSENSE_CLIENT;
 				const codeBlocks = document.querySelectorAll('pre');
 				codeBlocks.forEach((codeBlock) => {
 					if (codeBlock.querySelector('.copy-button')) return;
+					if (codeBlock.querySelector('code.language-kotlin')) return;
 
 					const button = document.createElement('button');
 					button.className = 'copy-button';
@@ -91,12 +96,22 @@ const adsClient = import.meta.env.PUBLIC_ADSENSE_CLIENT;
 				});
 			}
 
+			function initCoverImages() {
+				document.querySelectorAll('img.cover-img').forEach(img => {
+					img.addEventListener('error', () => {
+						img.parentElement?.remove();
+					});
+				});
+			}
+
 			initKotlinPlayground();
 			initCopyButtons();
+			initCoverImages();
 
 			document.addEventListener('astro:after-navigation', () => {
 				initKotlinPlayground();
 				initCopyButtons();
+				initCoverImages();
 			});
 
 			window.addEventListener('kotlin-playground-loaded', initKotlinPlayground);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 import PostList from '../../components/organisms/PostList';
 import Pagination from '../../components/molecules/Pagination';
+import TagSidebar from '../../components/organisms/TagSidebar.astro';
 
 const POSTS_PER_PAGE = 20;
 
@@ -11,10 +12,23 @@ const sortedPosts = allPosts.sort((a, b) => b.data.date.valueOf() - a.data.date.
 
 const totalPages = Math.max(1, Math.ceil(sortedPosts.length / POSTS_PER_PAGE));
 const posts = sortedPosts.slice(0, POSTS_PER_PAGE);
+
+const tagCounts = new Map<string, number>();
+allPosts.forEach(post => {
+  post.data.tags?.forEach(tag => {
+    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+  });
+});
+const tags = [...tagCounts.entries()].map(([name, count]) => ({ name, count }));
 ---
 
 <Layout title="Blog">
   <h1>Blog</h1>
-  <PostList posts={posts} />
-  <Pagination currentPage={1} totalPages={totalPages} indexPath="/blog" basePath="/blog/page" />
+  <div class="blog-layout">
+    <div style="flex: 1; min-width: 0;">
+      <PostList posts={posts} />
+      <Pagination currentPage={1} totalPages={totalPages} indexPath="/blog" basePath="/blog/page" />
+    </div>
+    <TagSidebar tags={tags} />
+  </div>
 </Layout>

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import Layout from '../../../layouts/Layout.astro';
 import PostList from '../../../components/organisms/PostList';
 import Pagination from '../../../components/molecules/Pagination';
+import TagSidebar from '../../../components/organisms/TagSidebar.astro';
 
 import type { GetStaticPaths } from 'astro';
 
@@ -20,15 +21,29 @@ interface Props {
 }
 
 const { page } = Astro.props;
+
+const allPosts = await getCollection('posts', ({ data }) => data.published !== false);
+const tagCounts = new Map<string, number>();
+allPosts.forEach(post => {
+  post.data.tags?.forEach(tag => {
+    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+  });
+});
+const tags = [...tagCounts.entries()].map(([name, count]) => ({ name, count }));
 ---
 
 <Layout title={`Blog — Page ${page.currentPage}`}>
   <h1>Blog <span style="font-weight: normal; color: #888;">— p.{page.currentPage}</span></h1>
-  <PostList posts={page.data} />
-  <Pagination
-    currentPage={page.currentPage}
-    totalPages={page.lastPage}
-    indexPath="/blog"
-    basePath="/blog/page"
-  />
+  <div class="blog-layout">
+    <div style="flex: 1; min-width: 0;">
+      <PostList posts={page.data} />
+      <Pagination
+        currentPage={page.currentPage}
+        totalPages={page.lastPage}
+        indexPath="/blog"
+        basePath="/blog/page"
+      />
+    </div>
+    <TagSidebar tags={tags} />
+  </div>
 </Layout>

--- a/src/plugins/remarkKotlin.ts
+++ b/src/plugins/remarkKotlin.ts
@@ -1,0 +1,26 @@
+type Node = { type: string; [key: string]: unknown };
+type Parent = Node & { children: Node[] };
+type CodeNode = Node & { lang: string | null; value: string };
+
+function escape(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export function remarkKotlin() {
+  return (tree: Node) => {
+    const children = (tree as Parent).children;
+    if (!Array.isArray(children)) return;
+    for (let i = 0; i < children.length; i++) {
+      const node = children[i] as CodeNode;
+      if (node.type === 'code' && node.lang === 'kotlin') {
+        children[i] = {
+          type: 'html',
+          value: `<pre><code class="language-kotlin">${escape(node.value)}</code></pre>`,
+        };
+      }
+    }
+  };
+}

--- a/src/plugins/remarkMermaid.ts
+++ b/src/plugins/remarkMermaid.ts
@@ -1,0 +1,26 @@
+type Node = { type: string; [key: string]: unknown };
+type Parent = Node & { children: Node[] };
+type CodeNode = Node & { lang: string | null; value: string };
+
+function escape(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export function remarkMermaid() {
+  return (tree: Node) => {
+    const children = (tree as Parent).children;
+    if (!Array.isArray(children)) return;
+    for (let i = 0; i < children.length; i++) {
+      const node = children[i] as CodeNode;
+      if (node.type === 'code' && node.lang === 'mermaid') {
+        children[i] = {
+          type: 'html',
+          value: `<div class="mermaid">\n${escape(node.value)}\n</div>`,
+        };
+      }
+    }
+  };
+}

--- a/src/plugins/remarkWikiLinks.ts
+++ b/src/plugins/remarkWikiLinks.ts
@@ -3,13 +3,17 @@ type Parent = Node & { children: Node[] };
 type TextNode = Node & { value: string };
 type LinkNode = Node & { url: string; title: null; children: TextNode[] };
 
+export interface WikiLinksOptions {
+  slugTitleMap?: Map<string, string>;
+}
+
 const WIKILINK_RE = /\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/g;
 
 function isParent(node: Node): node is Parent {
   return Array.isArray((node as Parent).children);
 }
 
-function processTextNode(node: TextNode): (TextNode | LinkNode)[] {
+function processTextNode(node: TextNode, slugTitleMap: Map<string, string>): (TextNode | LinkNode)[] {
   const { value } = node;
   if (!value.includes('[[')) return [node];
 
@@ -24,7 +28,8 @@ function processTextNode(node: TextNode): (TextNode | LinkNode)[] {
     }
 
     const slug = match[1].trim();
-    const displayText = match[2]?.trim() ?? slug;
+    const explicitText = match[2]?.trim();
+    const displayText = explicitText ?? slugTitleMap.get(slug) ?? slug;
 
     parts.push({
       type: 'link',
@@ -43,24 +48,25 @@ function processTextNode(node: TextNode): (TextNode | LinkNode)[] {
   return parts.length > 0 ? parts : [node];
 }
 
-function walk(node: Node): void {
+function walk(node: Node, slugTitleMap: Map<string, string>): void {
   if (!isParent(node)) return;
 
   const newChildren: Node[] = [];
   for (const child of node.children) {
     if (child.type === 'text') {
-      const replaced = processTextNode(child as TextNode);
+      const replaced = processTextNode(child as TextNode, slugTitleMap);
       newChildren.push(...replaced);
     } else {
-      walk(child);
+      walk(child, slugTitleMap);
       newChildren.push(child);
     }
   }
   node.children = newChildren;
 }
 
-export function remarkWikiLinks() {
+export function remarkWikiLinks(options: WikiLinksOptions = {}) {
+  const slugTitleMap = options.slugTitleMap ?? new Map<string, string>();
   return (tree: Node) => {
-    walk(tree);
+    walk(tree, slugTitleMap);
   };
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -217,6 +217,23 @@ footer .social-links {
   vertical-align: middle;
 }
 
+/* ---- Blog layout ---- */
+
+.blog-layout {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 560px) {
+  .blog-layout {
+    flex-direction: column;
+  }
+  .blog-layout aside {
+    width: 100% !important;
+  }
+}
+
 /* ---- Copy button (code blocks) ---- */
 
 .copy-button {


### PR DESCRIPTION
…k title display

- remarkMermaid/remarkKotlin plugins to bypass Shiki for CDN rendering
- Add mermaid.js CDN to Layout.astro
- Fix KotlinPlayground by bypassing Shiki processing
- Blog list: tag sidebar with client-side search
- PostCard: cover image (frontmatter URL or Picsum fallback)
- remarkWikiLinks: display article title instead of slug
- astro.config.mjs: build-time slug→title map via gray-matter
- package.json: add Firebase emulator scripts